### PR TITLE
zoom to area filter enabled/disabled correctly

### DIFF
--- a/js/actions/areafilter.js
+++ b/js/actions/areafilter.js
@@ -6,6 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 const RESIZE_HEIGHT = 'RESIZE_HEIGHT';
+const CHANGE_ZOOM_ARGS = 'CHANGE_ZOOM_ARGS';
+
+function changeZoomArgs(zoomArgs) {
+     return {
+         type: CHANGE_ZOOM_ARGS,
+         zoomArgs
+     };
+ }
 
 function resizeHeight(height) {
     return {
@@ -16,5 +24,7 @@ function resizeHeight(height) {
 
 module.exports = {
     RESIZE_HEIGHT,
-    resizeHeight
+    CHANGE_ZOOM_ARGS,
+    resizeHeight,
+    changeZoomArgs
 };

--- a/js/components/WMSCrossLayerFilter.jsx
+++ b/js/components/WMSCrossLayerFilter.jsx
@@ -19,6 +19,7 @@ const CoordinatesUtils = require('../../MapStore2/web/client/utils/CoordinatesUt
 const LhtacFilterUtils = require('../utils/LhtacFilterUtils');
 const WMSCrossLayerFilter = React.createClass({
     propTypes: {
+        zoomArgs: React.PropTypes.array,
         params: React.PropTypes.object,
         spatialField: React.PropTypes.object,
         toolbarEnabled: React.PropTypes.bool,
@@ -43,13 +44,14 @@ const WMSCrossLayerFilter = React.createClass({
                 onReset: () => {},
                 changeMapView: () => {},
                 createFilterConfig: () => {},
-                setBaseCqlFilter: () => {}
+                setBaseCqlFilter: () => {},
+                changeZoomArgs: () => {}
             }
         };
     },
     componentWillReceiveProps(nextProps) {
         if (nextProps.activeLayer.id !== this.props.activeLayer.id) {
-            this.zoomArgs = null;
+            this.props.actions.changeZoomArgs(null);
         }
     },
     render() {
@@ -64,10 +66,10 @@ const WMSCrossLayerFilter = React.createClass({
                     </Button>
                     <Button disabled={!this.props.toolbarEnabled} id="reset" onClick={this.reset}>
                         <Glyphicon glyph="glyphicon glyphicon-remove"/>
-                        <span style={{paddingLeft: "2px"}}><strong><I18N.Message msgId={"queryform.reset"}/></strong></span>
+                        <span style={{paddingLeft: "2px"}}><strong><I18N.Message msgId={"queryform.reset"}/ ></strong></span>
                     </Button>
                     <OverlayTrigger placement="right" overlay={(<Tooltip id="lab"><strong><I18N.Message msgId={"lhtac.crossfilter.zoomBtn"}/></strong></Tooltip>)}>
-                    <Button disabled={!this.props.toolbarEnabled || (this.zoomArgs === null || this.zoomArgs === undefined)} id="zoomtoarea" onClick={this.zoomToSelectedArea}>
+                    <Button disabled={!this.props.toolbarEnabled || (this.props.zoomArgs === null || this.props.zoomArgs === undefined)} id="zoomtoarea" onClick={this.zoomToSelectedArea}>
                         <Glyphicon glyph="resize-full"/>
                     </Button>
                     </OverlayTrigger>
@@ -120,22 +122,21 @@ const WMSCrossLayerFilter = React.createClass({
                 crs: "EPSG:4326",
                 rotation: 0
             }];
+            this.props.actions.changeZoomArgs(this.zoomArgs);
             this.props.actions.changeMapView(...this.zoomArgs, this.props.mapConfig.present.size, null, this.props.mapConfig.present.projection);
         }
-
         this.props.actions.setBaseCqlFilter(filter);
     },
     reset() {
-        this.zoomArgs = null;
+        this.props.actions.changeZoomArgs(null);
         this.props.actions.onReset();
         let params = assign(this.props.params, {cql_filter: "INCLUDE"});
         this.props.actions.onQuery(this.props.activeLayer, {params: params}, "INCLUDE");
     },
     zoomToSelectedArea() {
-        if (this.zoomArgs) {
-            this.props.actions.changeMapView(...this.zoomArgs, this.props.mapConfig.present.size, null, this.props.mapConfig.present.projection);
+        if (this.props.zoomArgs) {
+            this.props.actions.changeMapView(...this.props.zoomArgs, this.props.mapConfig.present.size, null, this.props.mapConfig.present.projection);
         }
-
     }
 });
 

--- a/js/plugins/AreaFilter.jsx
+++ b/js/plugins/AreaFilter.jsx
@@ -34,6 +34,10 @@ const {
     zoneGetValues
     } = require('../actions/lhtac');
 
+const {
+    changeZoomArgs
+} = require('../actions/areafilter');
+
 const SpatialFilter = connect((state) => ({
     useMapProjection: state.queryform.useMapProjection,
     spatialField: state.queryform.spatialField,
@@ -58,13 +62,15 @@ const {changeMapView} = require('../../MapStore2/web/client/actions/map');
 const WMSCrossSelector = createSelector([
         lhtac,
         (state) => (state.queryform.spatialField),
-        (state) => (state.map || {})
+        (state) => (state.map || {}),
+        (state) => (state)
         ],
-        (lhtacState, spatialField, mapConfig) => ({
+        (lhtacState, spatialField, mapConfig, state) => ({
             activeLayer: lhtacState.activeLayer,
             toolbarEnabled: true,
             spatialField,
-            mapConfig
+            mapConfig,
+            zoomArgs: state.areafilter.zoomArgs
         }));
 
 const WMSCrossLayerFilter = connect( WMSCrossSelector, (dispatch) => {
@@ -72,6 +78,7 @@ const WMSCrossLayerFilter = connect( WMSCrossSelector, (dispatch) => {
         actions: bindActionCreators({
             onQuery: changeLhtacLayerFilter,
             onReset: resetZones,
+            changeZoomArgs,
             changeMapView,
             createFilterConfig,
             setBaseCqlFilter

--- a/js/reducers/areafilter.js
+++ b/js/reducers/areafilter.js
@@ -7,8 +7,11 @@
  */
 
 const {
-    RESIZE_HEIGHT
+    RESIZE_HEIGHT,
+    CHANGE_ZOOM_ARGS
 } = require('../actions/areafilter');
+
+const assign = require('object-assign');
 
 const initialState = {
     expanded: true,
@@ -52,6 +55,9 @@ function areafilter(state = initialState, action) {
             let newStyle = {...state.layoutUpdates.style, height: "100%"};
             let newLayout = {...state.layoutUpdates, style: newStyle, resize: state.layoutUpdates.resize + 1};
             return {...state, layoutUpdates: newLayout};
+        }
+        case CHANGE_ZOOM_ARGS: {
+            return assign({}, state, {zoomArgs: action.zoomArgs});
         }
         default:
             return state;


### PR DESCRIPTION
ZoomArgs is now correctly passed to the WMSCrossLayerFilter via props.
When reset button is clicked or the layer changes the "zoom to area filter" button is disabled.