### PR TITLE
fixed #38 : bearing format output changed to decimal degrees

### DIFF
--- a/js/plugins/Measure.jsx
+++ b/js/plugins/Measure.jsx
@@ -7,11 +7,65 @@
  */
 const React = require('react');
 const {Glyphicon} = require('react-bootstrap');
+const {connect} = require('react-redux');
 
-let MSPlugin = require("../../MapStore2/web/client/plugins/Measure");
+const Message = require('../../MapStore2/web/client/plugins/locale/Message');
 
-MSPlugin.MeasurePlugin.Toolbar = {...MSPlugin.MeasurePlugin.Toolbar,
-            icon: <Glyphicon glyph="1-stilo"/>
+const lineRuleIcon = require('../../MapStore2/web/client/plugins/toolbar/assets/img/line-ruler.png');
+
+const assign = require('object-assign');
+
+const {changeMeasurementState} = require('../../MapStore2/web/client/actions/measurement');
+
+const Measure = require('../../MapStore2/web/client/components/mapcontrols/measure/MeasureComponent');
+
+const MeasureComponent = React.createClass({
+    render() {
+        const labels = {
+            lengthButtonText: <Message msgId="measureComponent.lengthButtonText"/>,
+            areaButtonText: <Message msgId="measureComponent.areaButtonText"/>,
+            resetButtonText: <Message msgId="measureComponent.resetButtonText"/>,
+            lengthLabel: <Message msgId="measureComponent.lengthLabel"/>,
+            areaLabel: <Message msgId="measureComponent.areaLabel"/>,
+            bearingLabel: <Message msgId="measureComponent.bearingLabel"/>
         };
+        return <Measure {...labels} {...this.props} formatBearing= {(value) => (value.toString() + '°')}/>;
+    }
+});
 
-module.exports = MSPlugin;
+const MeasurePlugin = connect((state) => {
+    return {
+        measurement: state.measurement || {},
+        lineMeasureEnabled: state.measurement && state.measurement.lineMeasureEnabled || false,
+        areaMeasureEnabled: state.measurement && state.measurement.areaMeasureEnabled || false,
+        bearingMeasureEnabled: state.measurement && state.measurement.bearingMeasureEnabled || false
+    };
+}, {
+    toggleMeasure: changeMeasurementState
+})(MeasureComponent);
+
+module.exports = {
+    MeasurePlugin: assign(MeasurePlugin, {
+        Toolbar: {
+            name: 'measurement',
+            position: 9,
+            panel: true,
+            exclusive: true,
+            wrap: true,
+            help: <Message msgId="helptexts.measureComponent"/>,
+            tooltip: "measureComponent.tooltip",
+            icon: <Glyphicon glyph="1-stilo"/>,
+            title: "measureComponent.title",
+            priority: 1
+        },
+        DrawerMenu: {
+            name: 'measurement',
+            position: 3,
+            icon: <img src={lineRuleIcon} />,
+            title: 'measureComponent.title',
+            showPanel: false,
+            priority: 2
+        }
+    }),
+    reducers: {measurement: require('../../MapStore2/web/client/reducers/measurement')}
+};


### PR DESCRIPTION
Now the bearing is in decimal degrees.
If you want to restore the previous format, just do not override the formatBearing function in the Measure plugin.
