### PR TITLE
fixed #46 : filterOGC created using all selected features

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,6 +80,7 @@
 				"name": "lhtac:web2014all_mv",
 				"group": "Safety",
 				"format": "image/png",
+        "fidAttributeName": "web2014all_mv_id",
         "legend": {
             "width": 20,
             "height": 20,
@@ -480,6 +481,7 @@
 				"name": "lhtac:bridge2014all_mv",
 				"group": "Bridges",
 				"format": "image/png",
+        "fidAttributeName": "bridge_num",
         "legend": {
             "width": 20,
             "height": 20,

--- a/config.json
+++ b/config.json
@@ -147,7 +147,8 @@
             {
                 "field": "properties.intersection_related",
                 "headerName": "Intersect Related",
-                "width": 70
+                "width": 70,
+                "type" : "boolean"
             },
             {
                 "field": "properties.street1",
@@ -192,12 +193,14 @@
             {
                 "field": "properties.impaired",
                 "headerName": "Impaired",
-                "width": 70
+                "width": 70,
+                "type" : "boolean"
             },
             {
                 "field": "properties.lane_dep",
                 "headerName": "Lane Depart",
-                "width": 70
+                "width": 70,
+                "type" : "boolean"
             },
             {
                 "field": "properties.first_harmful_event",
@@ -262,12 +265,12 @@
             {
                 "field": "properties.traffic_control_device",
                 "headerName": "Traffic Control Device",
-                "width": 100
+                "width": 110
             },
             {
                 "field": "properties.traffic_control_function",
                 "headerName": "Traffic Control Function",
-                "width": 100
+                "width": 110
             },
             {
                 "field": "properties.geometrics_horizontal",

--- a/js/actions/featureselector.js
+++ b/js/actions/featureselector.js
@@ -19,12 +19,11 @@ function featureSelectorReset() {
         type: FEATURE_SELECTOR_RESET
     };
 }
-function newGetFeatureRequest(reqId, filter, filterOpts) {
+function newGetFeatureRequest(reqId, filter) {
     return {
         type: NEW_GETFEATURE_REQUEST,
         reqId,
-        filter,
-        filterOpts
+        filter
     };
 }
 
@@ -54,10 +53,10 @@ function updateHighlightedFeatures(state, config, dispatch) {
     }
 }
 
-function loadFeatures(url, filter, add, filterOpts) {
+function loadFeatures(url, filter, add) {
     const reqId = uuid.v1();
     return (dispatch, getState) => {
-        dispatch(newGetFeatureRequest(reqId, filter, filterOpts));
+        dispatch(newGetFeatureRequest(reqId, filter));
         return axios.post(url, filter, {
             timeout: 10000,
             headers: {'Accept': 'application/json', 'Content-Type': 'text/plain'}

--- a/js/components/BooleanCellRenderer.jsx
+++ b/js/components/BooleanCellRenderer.jsx
@@ -1,0 +1,17 @@
+
+const React = require('react');
+
+const BooleanCellRenderer = React.createClass({
+    propTypes: {
+        params: React.PropTypes.object
+    },
+    render() {
+        let field = this.props.params.colDef.field;
+        let myProp = field.substr("properties.".length, field.length);
+        let ret = this.props.params.data.properties[myProp].toString();
+        return <span>{ret}</span>;
+    }
+});
+
+
+module.exports = BooleanCellRenderer;

--- a/js/components/LhtacFeatureGrid.jsx
+++ b/js/components/LhtacFeatureGrid.jsx
@@ -8,12 +8,15 @@
 
 
 const React = require('react');
+const {reactCellRendererFactory} = require('ag-grid-react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 const {isEqual} = require('lodash');
 const FeatureGrid = require('../../MapStore2/web/client/components/data/featuregrid/FeatureGrid');
 const {updateHighlighted } = require('../../MapStore2/web/client/actions/highlight');
 const lhtac = require('../selectors/lhtac');
+const BooleanCellRenderer = require('../components/BooleanCellRenderer');
+const assign = require("object-assign");
 
 const LhtacFeatureGrid = React.createClass({
     propTypes: {
@@ -44,6 +47,16 @@ const LhtacFeatureGrid = React.createClass({
             nextProps.style !== this.props.style || (!isEqual(nextProps.features, this.props.features)) || true);
     },
     render() {
+        // Adding the cellRenderer only to the following 3 properties that are booelan fields (instead of false there is null.
+        // So when the value is null it returns "false" otherwise "true")
+        let newColumnsDef = this.props.activeLayer && this.props.activeLayer.columnDefs || [];
+        // let fieldsToTransform = ["properties.intersection_related", "properties.impaired", "properties.lane_dep"];
+        let newColumns = newColumnsDef.map((col) => {
+            return (col.type !== undefined && col.type === "boolean") ?
+                assign({}, col, {cellRenderer: reactCellRendererFactory(BooleanCellRenderer)}) :
+                col;
+        });
+
         return (this.props.features.length > 0) ? (
             <FeatureGrid
                 style={this.props.style}
@@ -51,7 +64,7 @@ const LhtacFeatureGrid = React.createClass({
                 selectFeatures={this.highligthFeatures}
                 highlightedFeatures={this.props.highlightedFeatures}
                 enableZoomToFeature={false}
-                columnDefs={this.props.activeLayer.columnDefs}
+                columnDefs={newColumns}
                 excludeFields={this.props.activeLayer.excludeFields}
                 agGridOptions={{headerHeight: 48}}
                 toolbar={{zoom: false, exporter: false, toolPanel: false}}

--- a/js/components/Statistics.jsx
+++ b/js/components/Statistics.jsx
@@ -86,7 +86,9 @@ const Statistics = React.createClass({
             this.props.selectedfeatures.features.length > 0 &&
             this.props.selectedfeatures.request &&
             this.props.selectedfeatures.request.filterOpts) {
-            this.wfsFilterBody = LhtacFilterUtils.processOGCSpatialFilter(this.props.selectedfeatures.request.filterOpts, "1.1.0");
+            // the wfsFilterBody is built from the list of the features in featureselector
+            const attributeName = this.props.activeLayer.fidAttributeName;
+            this.wfsFilterBody = LhtacFilterUtils.processOGCIdFilter(this.props.selectedfeatures.features, attributeName, "OR", "1.1.0");
         }
         if (this.props.selectedfeatures.features.length > 0) {
             selectedFilterLink.onClick = () => { this.downloadFile(); };

--- a/js/components/Statistics.jsx
+++ b/js/components/Statistics.jsx
@@ -84,8 +84,7 @@ const Statistics = React.createClass({
         // needs to be checked also if there the request is correct and without errors
         if (this.props.selectedfeatures &&
             this.props.selectedfeatures.features.length > 0 &&
-            this.props.selectedfeatures.request &&
-            this.props.selectedfeatures.request.filterOpts) {
+            this.props.selectedfeatures.request) {
             // the wfsFilterBody is built from the list of the features in featureselector
             const attributeName = this.props.activeLayer.fidAttributeName;
             this.wfsFilterBody = LhtacFilterUtils.processOGCIdFilter(this.props.selectedfeatures.features, attributeName, "OR", "1.1.0");

--- a/js/containers/containerStyle.css
+++ b/js/containers/containerStyle.css
@@ -1,4 +1,4 @@
-#south-panel .ag-header-cell{
+#south-panel .ag-header-cell, #south-panel .ag-header-row{
     background-color: #078AA3 !important;
     color: white !important;
     font-family: Raleway !important;

--- a/js/plugins/FeatureSelector.jsx
+++ b/js/plugins/FeatureSelector.jsx
@@ -129,9 +129,8 @@ const FeatureSelector = React.createClass({
                 if (this.props.advancedFilterStatus && this.props.queryform.simpleFilterFields && this.props.queryform.simpleFilterFields.length > 0) {
                     filterOpt.simpleFilterFields = this.props.queryform.simpleFilterFields;
                 }
-                // TODO : review and comment following lines
                 let ogcFilter = FilterUtils.toOGCFilter(nextProps.activeLayer.name, filterOpt, "1.1.0");
-                this.props.loadFeatures(nextProps.queryform.searchUrl, ogcFilter, this.addKey, filterOpt);
+                this.props.loadFeatures(nextProps.queryform.searchUrl, ogcFilter, this.addKey);
                 if (!this.addKey) {
                     // features selected and highlighted will be cleaned if the CTRL button is NOT pressed
                     this.props.changeHighlightStatus('disabled');

--- a/js/plugins/FeatureSelector.jsx
+++ b/js/plugins/FeatureSelector.jsx
@@ -106,13 +106,16 @@ const FeatureSelector = React.createClass({
             // Check SRS & Type
             let sFieldSRS = spatialField.geometry && spatialField.geometry.projection || "EPSG:4326";
             let sFieldType = spatialField.geometry.type || "Polygon";
-
+            // prevGeometry is the area selected in the areaFilter and changes only over there
             let prevGeometry = {
                 coordinates: spatialField.geometry.coordinates,
                 projection: sFieldSRS,
                 type: sFieldType
             };
 
+            // this intersetions refers to the geometry given by the areaFilter and the last area selected with the drawing tool.
+            // in the featureSelector reducer the state is updated doing a xor beetwen the old selected features and the new ones
+            // implementing the toggle of the features (selected or highlghted ones become unselected and unselected ones become selected)
             let intersection = FeatureSelectorUtils.intersectPolygons(prevGeometry, nextProps.geometry);
 
             if (intersection !== undefined) {
@@ -126,9 +129,11 @@ const FeatureSelector = React.createClass({
                 if (this.props.advancedFilterStatus && this.props.queryform.simpleFilterFields && this.props.queryform.simpleFilterFields.length > 0) {
                     filterOpt.simpleFilterFields = this.props.queryform.simpleFilterFields;
                 }
+                // TODO : review and comment following lines
                 let ogcFilter = FilterUtils.toOGCFilter(nextProps.activeLayer.name, filterOpt, "1.1.0");
                 this.props.loadFeatures(nextProps.queryform.searchUrl, ogcFilter, this.addKey, filterOpt);
                 if (!this.addKey) {
+                    // features selected and highlighted will be cleaned if the CTRL button is NOT pressed
                     this.props.changeHighlightStatus('disabled');
                 }
                 this.addKey = false;

--- a/js/reducers/featureselector.js
+++ b/js/reducers/featureselector.js
@@ -37,7 +37,7 @@ function featureselector(state = initialState, action) {
 
         }
         case NEW_GETFEATURE_REQUEST: {
-            return {...state, geometryStatus: "consumed", error: false, request: {id: action.reqId, state: "loading", filter: action.filter, filterOpts: action.filterOpts }};
+            return {...state, geometryStatus: "consumed", error: false, request: {id: action.reqId, state: "loading", filter: action.filter }};
         }
         case FEATURE_SELECTOR_ERROR: {
             return {...state, error: action.error, geometryStatus: "consumed", geometry: undefined, request: {}};

--- a/js/utils/LhtacFilterUtils.js
+++ b/js/utils/LhtacFilterUtils.js
@@ -29,7 +29,6 @@ const BaseFilter = '<?xml version="1.0" encoding="UTF-8"?><wps:Execute version="
                   '</wps:ResponseForm>' +
                 '</wps:Execute>';
 
-
 const LhtacFilterUtils = {
     propertyTagReference: {
         "1.0.0": {startTag: "<PropertyName>", endTag: "</PropertyName>"},
@@ -42,6 +41,9 @@ const LhtacFilterUtils = {
         "CONTAINS": {startTag: "<Contains>", endTag: "</Contains>"},
         "DWITHIN": {startTag: "<DWithin>", endTag: "</DWithin>"},
         "WITHIN": {startTag: "<Within>", endTag: "</Within>"}
+    },
+    ogcLogicalOperator: {
+        "OR": {startTag: "<Or>", endTag: "</Or>"}
     },
     getWpsRequest(typeName, cqlFilter, attribute) {
         let cql = encodeURI(cqlFilter);
@@ -180,6 +182,32 @@ const LhtacFilterUtils = {
         }
 
         ogc += this.ogcSpatialOperator[objFilter.spatialField.operation].endTag;
+
+        filter += ogc;
+        filter += '</Filter>';
+
+        return filter;
+    },
+    // created from a list of features id
+    processOGCIdFilter: function(features, attributeName, logicalOperator, version) {
+        let filter = '<Filter>';
+
+        let ogc = this.ogcLogicalOperator[logicalOperator].startTag;
+
+        // building the list of options inside or operator
+        features.forEach((element) => {
+            if (element) {
+                ogc += "<PropertyIsEqualTo>" +
+                        this.propertyTagReference[version].startTag +
+                        attributeName +
+                        this.propertyTagReference[version].endTag;
+                ogc += "<Literal>" +
+                        element.properties[attributeName] +
+                         "</Literal></PropertyIsEqualTo>";
+            }
+        });
+
+        ogc += this.ogcLogicalOperator[logicalOperator].endTag;
 
         filter += ogc;
         filter += '</Filter>';


### PR DESCRIPTION
In order to download all and only the selected features a different OGCFilter is created. Now it is created like this:

```
<Filter>
 <Or>
  <PropertyIsEqualTo>
    <attributeName>attr_name</attributeName>
    <Literal>attr_value</Literal>
  </PropertyIsEqualTo>
  </Or>
</Filter>
```

where attribute name is obtained from the active layer.