### PR TITLE
typo in print plugin

### DIFF
--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -140,11 +140,11 @@
             }
         },
         "print":{
-            "paneltitle": "Print",
+            "paneltitle": "Create PDF",
             "layout": "Layout",
             "sheetsize": "Sheet size:",
             "legendoptions": "Legend options",
-            "submit": "Crete PDF",
+            "submit": "Create PDF",
             "title": "Title",
             "titleplaceholder": "Enter a title...",
             "description": "Description",


### PR DESCRIPTION
Changed title of the panel from "print" to "create PDF"
Fixed a typo in submit button