### PR TITLE
Fixed #53 : changes applied to Area Filter

### DIFF
--- a/config.json
+++ b/config.json
@@ -305,7 +305,6 @@
         ],
         "advancedFilter": {
             "searchUrl": "http://demo.geo-solutions.it/geoserver/ows?service=WPS",
-            "type": "WPS",
             "cql": "INCLUDE",
             "fieldsConfig": [
                 {
@@ -578,7 +577,6 @@
         ],
         "advancedFilter": {
             "searchUrl": "http://demo.geo-solutions.it/geoserver/ows?service=WPS",
-            "type": "WPS",
             "cql": "INCLUDE",
             "fieldsConfig": [
                 {

--- a/js/actions/lhtac.js
+++ b/js/actions/lhtac.js
@@ -12,27 +12,17 @@ const SET_ACTIVE_ZONE = 'SET_ACTIVE_ZONE';
 const CHANGE_LAYER_PROPERTIES = 'CHANGE_LAYER_PROPERTIES';
 const STATS_LOADING = 'STATS_LOADING';
 const CHANGE_DOWNLOAD_FORMAT = 'CHANGE_DOWNLOAD_FORMAT';
+const ZONE_CHANGE = 'ZONE_CHANGE';
+const CLEAN_GEOMETRY = 'CLEAN_GEOMETRY';
+const CLEAN_ZONE = 'CLEAN_ZONE';
 
 const {changeLayerProperties} = require('../../MapStore2/web/client/actions/layers');
 const {zoneSearchError, zoneFilter, zoneSearch} = require('../../MapStore2/web/client/actions/queryform');
 const {featureSelectorError} = require("../actions/featureselector");
+const {onResetThisZone} = require("../actions/queryform");
 
 const FileUtils = require('../../MapStore2/web/client/utils/FileUtils');
 
-function switchLayer(layer) {
-    return {
-        type: SWITCH_LAYER,
-        layer
-    };
-}
-function setActiveZone(id, value, exclude) {
-    return {
-        type: SET_ACTIVE_ZONE,
-        id,
-        value,
-        exclude
-    };
-}
 function statsLoading(status) {
     return {
         type: "STATS_LOADING",
@@ -96,6 +86,57 @@ function changeLhtacLayerFilter(layer, properties, areaFilter) {
             results.sort((a, b) => (a.id - b.id) );
             dispatch(changeLayerProperties(layer.id, {statistics: results}));
         });
+    };
+}
+function switchLayer(layer) {
+    return {
+        type: SWITCH_LAYER,
+        layer
+    };
+}
+function setActiveZone(id, exclude) {
+    return {
+        type: SET_ACTIVE_ZONE,
+        id,
+        exclude
+    };
+}
+
+function zoneChange(id, value) {
+    return {
+        type: ZONE_CHANGE,
+        id,
+        value
+    };
+}
+function cleanGeometry() {
+    return {
+        type: CLEAN_GEOMETRY
+    };
+}
+function cleanZone(zoneId) {
+    return {
+        type: CLEAN_ZONE,
+        zoneId
+    };
+}
+
+function zoneSelected(zone, value, exclude) {
+    return (dispatch) => {
+        // clean previous geometry
+        if (zone.active && value && value.value && value.value.length > 0 &&
+            value.feature && value.feature.length > 0) {
+            dispatch(cleanGeometry());
+        }
+        if (value && value.value && value.value.length === 0) {
+            dispatch(onResetThisZone(zone.id, false));
+        }
+        // if there is a value in the zoneField update the geometry
+        if (value && value.value && value.value.length > 0 &&
+            value.feature && value.feature.length > 0) {
+            dispatch(zoneChange(zone.id, value));
+            dispatch(setActiveZone(zone.id, exclude));
+        }
     };
 }
 
@@ -175,11 +216,18 @@ module.exports = {
     CHANGE_LAYER_PROPERTIES,
     STATS_LOADING,
     CHANGE_DOWNLOAD_FORMAT,
+    ZONE_CHANGE,
+    CLEAN_GEOMETRY,
+    CLEAN_ZONE,
+    cleanZone,
+    cleanGeometry,
+    zoneChange,
     changeLhtacLayerFilter,
     switchLayer,
     setActiveZone,
     changeDownloadFormat,
     getNumberOfFeatures,
     zoneGetValues,
-    downloadSelectedFeatures
+    downloadSelectedFeatures,
+    zoneSelected
 };

--- a/js/actions/queryform.js
+++ b/js/actions/queryform.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const ON_RESET_THIS_ZONE = 'ON_RESET_THIS_ZONE';
+
+
+function onResetThisZone(zoneId, reload) {
+    return {
+        type: ON_RESET_THIS_ZONE,
+        zoneId,
+        reload
+    };
+}
+
+module.exports = {
+    ON_RESET_THIS_ZONE,
+    onResetThisZone
+};

--- a/js/components/LhtacSpatialFilter.jsx
+++ b/js/components/LhtacSpatialFilter.jsx
@@ -7,12 +7,17 @@
  */
 const React = require('react');
 
-const { Panel, Button, ButtonToolbar} = require('react-bootstrap');
+const { Panel, Button, ButtonToolbar, Grid, Row, Col} = require('react-bootstrap');
 
 const ZoneField = require('../../MapStore2/web/client/components/data/query/ZoneField');
 
 const SpatialFilter = React.createClass({
     propTypes: {
+        activeLayer: React.PropTypes.object,
+        params: React.PropTypes.object,
+        mapConfig: React.PropTypes.object,
+        zoomArgs: React.PropTypes.array,
+
         useMapProjection: React.PropTypes.bool,
         spatialField: React.PropTypes.object,
         spatialOperations: React.PropTypes.array,
@@ -39,12 +44,42 @@ const SpatialFilter = React.createClass({
                 {id: "INTERSECTS", name: "queryform.spatialfilter.operations.intersects"}
             ],
             actions: {
-                setActiveZone: () => {},
                 zoneFilter: () => {},
                 zoneSearch: () => {},
+                zoneSelected: () => {},
                 zoneChange: () => {}
             }
         };
+    },
+    getValues(zone) {
+        let value = zone && zone.value;
+        let val = null;
+        if (value !== null) {
+            let values = zone.values;
+            let features = [];
+            if (values && values.length > 0) {
+
+                features = values.filter((v) => {
+                    let valueField2 = v;
+                    zone.valueField.split('.').forEach(part => {
+                        valueField2 = valueField2 ? valueField2[part] : null;
+                    });
+                    return value.includes(valueField2);
+                });
+            }
+            if (zone && zone.multivalue) {
+                val = {
+                    value: value,
+                    feature: features
+                };
+            } else {
+                val = {
+                    value: [value],
+                    feature: [features]
+                };
+            }
+        }
+        return val;
     },
     renderToolbar() {
         return (
@@ -54,6 +89,24 @@ const SpatialFilter = React.createClass({
       </ButtonToolbar>
             );
     },
+    renderRadios(zone) {
+        let value = this.getValues(zone);
+        return (
+          <label key={zone.id} style={{marginLeft: "0px", marginTop: "31px"}}>
+            <input
+              name="zoneField"
+              type="radio"
+              value={zone.id}
+              checked={zone.checked}
+              readOnly={!zone.checked}
+              defaultChecked={false}
+              onChange={() => {}}
+              disabled={zone.value === null}
+              onClick={() => {this.props.actions.zoneSelected(zone, value, zone.exclude); }}
+            />
+          </label>
+       );
+    },
     renderZoneFields() {
         return this.props.spatialField.method &&
             this.props.spatialField.method === "ZONE" &&
@@ -61,33 +114,42 @@ const SpatialFilter = React.createClass({
             this.props.spatialField.zoneFields.length > 0 ?
                 this.props.spatialField.zoneFields.map((zone) => {
                     return (
-                        <div key={zone.id} className={zone.active && zone.value && Array.isArray(zone.value) && zone.value.length > 0 ? "active-zone" : ''}>
-                        <ZoneField
-                            open={zone.open}
-                            zoneId={zone.id}
-                            url={zone.url}
-                            typeName={zone.typeName}
-                            wfs={zone.wfs}
-                            busy={zone.busy}
-                            label={zone.label}
-                            values={zone.values}
-                            value={zone.value}
-                            valueField={zone.valueField}
-                            textField={zone.textField}
-                            searchText={zone.searchText}
-                            searchMethod={zone.searchMethod}
-                            searchAttribute={zone.searchAttribute}
-                            sort={zone.sort}
-                            error={zone.error}
-                            disabled={zone.disabled}
-                            dependsOn={zone.dependson}
-                            groupBy={zone.groupBy}
-                            multivalue={zone.multivalue}
-                            onSearch={this.props.actions.zoneSearch}
-                            onFilter={this.props.actions.zoneFilter}
-                            onChange={this.zoneChange}/>
-                            {(zone.toolBar) ? this.renderToolbar() : null}
-                            </div>
+                        <div key={zone.id} className={zone.active ? "active-zone" : ''}>
+                          <Grid fluid>
+                            <Row>
+                               <Col xs={1}>{this.renderRadios(zone)}</Col>
+                               <Col xs={11}>
+                                <ZoneField
+                                    open={zone.open}
+                                    zoneId={zone.id}
+                                    url={zone.url}
+                                    typeName={zone.typeName}
+                                    wfs={zone.wfs}
+                                    busy={zone.busy}
+                                    label={zone.label}
+                                    values={zone.values}
+                                    value={zone.value}
+                                    valueField={zone.valueField}
+                                    textField={zone.textField}
+                                    searchText={zone.searchText}
+                                    searchMethod={zone.searchMethod}
+                                    searchAttribute={zone.searchAttribute}
+                                    sort={zone.sort}
+                                    error={zone.error}
+                                    disabled={zone.disabled}
+                                    dependsOn={zone.dependson}
+                                    groupBy={zone.groupBy}
+                                    multivalue={zone.multivalue}
+                                    onSearch={this.props.actions.zoneSearch}
+                                    onFilter={this.props.actions.zoneFilter}
+                                    onChange={this.zoneChange}/></Col>
+                              </Row>
+                              <Row>
+                                <Col xs={1}><span/></Col>
+                                <Col xs={11}>{(zone.toolbar) ? this.renderToolbar() : null}</Col>
+                              </Row>
+                            </Grid>
+                        </div>
                     );
                 }) : (<span/>);
     },
@@ -106,12 +168,18 @@ const SpatialFilter = React.createClass({
         );
     },
     zoneChange(id, value) {
+        // find the zonefield related to the last selected value
         let zoneField = this.props.spatialField.zoneFields.find((z) => {return z.id === id; });
+
+        /*if ( value.value && value.value.length > 0 &&
+            value.feature && value.feature.length > 0) {*/
+            // if there are some exluded zone set this to be active otherwise...
         if (zoneField && zoneField.exclude && zoneField.exclude.length > 0) {
-            this.props.actions.setActiveZone(id, value, zoneField.exclude);
+            this.props.actions.zoneSelected(zoneField, value, zoneField.exclude);
         }else {
             this.props.actions.zoneChange(id, value);
         }
+      //  }
     }
 });
 

--- a/js/components/WMSCrossLayerFilter.jsx
+++ b/js/components/WMSCrossLayerFilter.jsx
@@ -24,6 +24,7 @@ const WMSCrossLayerFilter = React.createClass({
         spatialField: React.PropTypes.object,
         toolbarEnabled: React.PropTypes.bool,
         mapConfig: React.PropTypes.object,
+        mapInitialConfig: React.PropTypes.object,
         showGeneratedFilter: React.PropTypes.oneOfType([
             React.PropTypes.bool,
             React.PropTypes.string
@@ -42,6 +43,7 @@ const WMSCrossLayerFilter = React.createClass({
             actions: {
                 onQuery: () => {},
                 onReset: () => {},
+                onResetThisZone: () => {},
                 changeMapView: () => {},
                 createFilterConfig: () => {},
                 setBaseCqlFilter: () => {},
@@ -53,17 +55,32 @@ const WMSCrossLayerFilter = React.createClass({
         if (nextProps.activeLayer.id !== this.props.activeLayer.id) {
             this.props.actions.changeZoomArgs(null);
         }
+        if (nextProps.spatialField.geometry !== this.props.spatialField.geometry) {
+            for (let i = 0; i < nextProps.spatialField.zoneFields.length; i++ ) {
+                let z = nextProps.spatialField.zoneFields[i];
+                if (z.active === true && z.value !== null) {
+                    this.search(nextProps);
+                }
+            }
+        }
+        if (!nextProps.spatialField.buttonReset) {
+            for (let i = 0; i < nextProps.spatialField.zoneFields.length; i++ ) {
+                let nextZone = nextProps.spatialField.zoneFields[i];
+                let thisZone = this.props.spatialField.zoneFields[i];
+                if (thisZone.value && nextZone.value === null && thisZone.active) {
+                    this.resetThisZone(nextZone.id, true);
+                }
+                if (thisZone.value && nextZone.value === null && !thisZone.active) {
+                    this.resetThisZone(nextZone.id, false);
+                }
+            }
+        }
     },
     render() {
-        let queryDisabled = !this.props.toolbarEnabled || !this.props.spatialField.geometry;
-
+        // search button was removed because every time a value is selected or a zone is witched it updates automatically the map
         return (
             <div>
                 <ButtonToolbar className="crossFilterToolbar">
-                    <Button disabled={queryDisabled} id="query" onClick={this.search}>
-                        <Glyphicon glyph="glyphicon glyphicon-search"/>
-                        <span style={{paddingLeft: "2px"}}><strong><I18N.Message msgId={"queryform.query"}/></strong></span>
-                    </Button>
                     <Button disabled={!this.props.toolbarEnabled} id="reset" onClick={this.reset}>
                         <Glyphicon glyph="glyphicon glyphicon-remove"/>
                         <span style={{paddingLeft: "2px"}}><strong><I18N.Message msgId={"queryform.reset"}/ ></strong></span>
@@ -88,50 +105,68 @@ const WMSCrossLayerFilter = React.createClass({
             </div>
         );
     },
-    search() {
+    search(props) {
 
-        let filter = LhtacFilterUtils.getZoneCrossFilter(this.props.spatialField);
+        let filter = LhtacFilterUtils.getZoneCrossFilter(props.spatialField);
 
-        let params = assign({}, this.props.params, {cql_filter: filter});
-        this.props.actions.onQuery(this.props.activeLayer, {params: params}, filter);
+        if (filter) {
+            let params = assign({}, props.params, {cql_filter: filter});
+            props.actions.onQuery(props.activeLayer, {params: params}, filter);
 
-        // ////////////////////////////////////////////////////////////////////
-        // WPS request to retrieve attribute values for the advanced filter
-        // ////////////////////////////////////////////////////////////////////
-        if (this.props.activeLayer && this.props.activeLayer.advancedFilter) {
-            this.props.activeLayer.advancedFilter.fieldsConfig.map((field) => {
-                let wpsRequest = LhtacFilterUtils.getWpsRequest(this.props.activeLayer.name, this.props.activeLayer.advancedFilter.cql || filter, field.attribute);
-                this.props.actions.createFilterConfig(wpsRequest, this.props.activeLayer.advancedFilter.searchUrl, field);
-            }, this);
+            // ////////////////////////////////////////////////////////////////////
+            // WPS request to retrieve attribute values for the advanced filter
+            // ////////////////////////////////////////////////////////////////////
+            if (props.activeLayer && props.activeLayer.advancedFilter) {
+                props.activeLayer.advancedFilter.fieldsConfig.map((field) => {
+                    let wpsRequest = LhtacFilterUtils.getWpsRequest(props.activeLayer.name, props.activeLayer.advancedFilter.cql || filter, field.attribute);
+                    props.actions.createFilterConfig(wpsRequest, props.activeLayer.advancedFilter.searchUrl, field);
+                }, this);
+            }
+
+            // Zoom to the selected geometry
+            if (props.spatialField.geometry && props.spatialField.geometry.extent) {
+                const bbox = props.spatialField.geometry.extent;
+                const mapSize = props.mapConfig.present.size;
+
+                const newZoom = mapUtils.getZoomForExtent(CoordinatesUtils.reprojectBbox(bbox, "EPSG:4326", props.mapConfig.present.projection), mapSize, 0, 21, null);
+                const newCenter = mapUtils.getCenterForExtent(bbox, "EPSG:4326");
+                this.zoomArgs = [newCenter, newZoom, {
+                    bounds: {
+                       minx: bbox[0],
+                       miny: bbox[1],
+                       maxx: bbox[2],
+                       maxy: bbox[3]
+                    },
+                    crs: "EPSG:4326",
+                    rotation: 0
+                }];
+                props.actions.changeZoomArgs(this.zoomArgs);
+                props.actions.changeMapView(...this.zoomArgs, props.mapConfig.present.size, null, props.mapConfig.present.projection);
+            }
+            props.actions.setBaseCqlFilter(filter);
         }
 
-        // Zoom to the selected geometry
-        if (this.props.spatialField.geometry && this.props.spatialField.geometry.extent) {
-            const bbox = this.props.spatialField.geometry.extent;
-            const mapSize = this.props.mapConfig.present.size;
-
-            const newZoom = mapUtils.getZoomForExtent(CoordinatesUtils.reprojectBbox(bbox, "EPSG:4326", this.props.mapConfig.present.projection), mapSize, 0, 21, null);
-            const newCenter = mapUtils.getCenterForExtent(bbox, "EPSG:4326");
-            this.zoomArgs = [newCenter, newZoom, {
-                bounds: {
-                   minx: bbox[0],
-                   miny: bbox[1],
-                   maxx: bbox[2],
-                   maxy: bbox[3]
-                },
-                crs: "EPSG:4326",
-                rotation: 0
-            }];
-            this.props.actions.changeZoomArgs(this.zoomArgs);
-            this.props.actions.changeMapView(...this.zoomArgs, this.props.mapConfig.present.size, null, this.props.mapConfig.present.projection);
-        }
-        this.props.actions.setBaseCqlFilter(filter);
+    },
+    zoomToInitialExtent() {
+        let mapConfig = this.props.mapInitialConfig;
+        let bbox = mapUtils.getBbox(mapConfig.center, mapConfig.zoom, this.props.mapConfig.size);
+        this.props.actions.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, mapConfig.projection);
     },
     reset() {
         this.props.actions.changeZoomArgs(null);
         this.props.actions.onReset();
         let params = assign(this.props.params, {cql_filter: "INCLUDE"});
         this.props.actions.onQuery(this.props.activeLayer, {params: params}, "INCLUDE");
+        this.zoomToInitialExtent();
+    },
+    resetThisZone(zoneId, reload) {
+        this.props.actions.onResetThisZone(zoneId, reload);
+        if (reload) {
+            this.props.actions.changeZoomArgs(null);
+            let params = assign(this.props.params, {cql_filter: "INCLUDE"});
+            this.props.actions.onQuery(this.props.activeLayer, {params: params}, "INCLUDE");
+            this.zoomToInitialExtent();
+        }
     },
     zoomToSelectedArea() {
         if (this.props.zoomArgs) {

--- a/js/plugins/AreaFilter.jsx
+++ b/js/plugins/AreaFilter.jsx
@@ -30,46 +30,62 @@ const {
 
 const {
     setActiveZone,
+    zoneSelected,
     changeLhtacLayerFilter,
-    zoneGetValues
+    zoneGetValues,
+    cleanZone
     } = require('../actions/lhtac');
+
+const {
+    onResetThisZone
+} = require('../actions/queryform');
 
 const {
     changeZoomArgs
 } = require('../actions/areafilter');
 
-const SpatialFilter = connect((state) => ({
-    useMapProjection: state.queryform.useMapProjection,
-    spatialField: state.queryform.spatialField,
-    showDetailsPanel: state.queryform.showDetailsPanel,
-    withContainer: state.queryform.withContainer,
-    spatialMethodOptions: state.queryform.spatialMethodOptions,
-    spatialOperations: state.queryform.spatialOperations
-}), (dispatch) => {
+const {changeMapView} = require('../../MapStore2/web/client/actions/map');
+
+
+const SpatialFilterSelector = createSelector([
+        (state) => (state)
+        ],
+        (state) => ({
+            useMapProjection: state.queryform.useMapProjection,
+            spatialField: state.queryform.spatialField,
+            showDetailsPanel: state.queryform.showDetailsPanel,
+            withContainer: state.queryform.withContainer,
+            spatialMethodOptions: state.queryform.spatialMethodOptions,
+            spatialOperations: state.queryform.spatialOperations
+        }));
+
+const SpatialFilter = connect(SpatialFilterSelector, (dispatch) => {
     return {
         actions: bindActionCreators({
             onRemoveSpatialSelection: removeSpatialSelection,
             zoneFilter: zoneGetValues,
             zoneSearch,
             setActiveZone,
+            zoneSelected,
+            cleanZone,
             zoneChange
         }, dispatch)
     };
 })(require('../components/LhtacSpatialFilter'));
 
-const {changeMapView} = require('../../MapStore2/web/client/actions/map');
-
 const WMSCrossSelector = createSelector([
         lhtac,
         (state) => (state.queryform.spatialField),
         (state) => (state.map || {}),
+        (state) => (state.mapInitialConfig || {}),
         (state) => (state)
         ],
-        (lhtacState, spatialField, mapConfig, state) => ({
+        (lhtacState, spatialField, mapConfig, mapInitialConfig, state) => ({
             activeLayer: lhtacState.activeLayer,
             toolbarEnabled: true,
             spatialField,
             mapConfig,
+            mapInitialConfig,
             zoomArgs: state.areafilter.zoomArgs
         }));
 
@@ -78,6 +94,7 @@ const WMSCrossLayerFilter = connect( WMSCrossSelector, (dispatch) => {
         actions: bindActionCreators({
             onQuery: changeLhtacLayerFilter,
             onReset: resetZones,
+            onResetThisZone,
             changeZoomArgs,
             changeMapView,
             createFilterConfig,

--- a/js/reducers/advancedfilter.js
+++ b/js/reducers/advancedfilter.js
@@ -42,6 +42,9 @@ function advancedfilter(state = initialState, action) {
         case 'ZONES_RESET': {
             return {...state, error: false};
         }
+        case 'ON_RESET_THIS_ZONE': {
+            return (action.reload) ? {...state, error: false} : {...state};
+        }
         case 'SWITCH_LAYER': {
             return initialState;
         }

--- a/js/reducers/areafilter.js
+++ b/js/reducers/areafilter.js
@@ -40,6 +40,11 @@ function areafilter(state = initialState, action) {
             let newLayout = {...state.layoutUpdates, style: newStyle, resize: state.layoutUpdates.resize + 1};
             return {...state, layoutUpdates: newLayout};
         }
+        case 'ON_RESET_THIS_ZONE': {
+            let newStyle = {...state.layoutUpdates.style, height: "100%"};
+            let newLayout = {...state.layoutUpdates, style: newStyle, resize: state.layoutUpdates.resize + 1};
+            return (action.reload) ? {...state, layoutUpdates: newLayout} : {...state};
+        }
         case 'BASE_CQL_FILTER': {
             let newStyle = {...state.layoutUpdates.style, height: "100%"};
             let newLayout = {...state.layoutUpdates, style: newStyle, resize: state.layoutUpdates.resize + 1};

--- a/js/reducers/draw.js
+++ b/js/reducers/draw.js
@@ -35,6 +35,14 @@ function draw(state, action) {
                 features: []
             };
         }
+        case 'ON_RESET_THIS_ZONE': {
+            return (action.reload) ? {...state,
+                drawStatus: 'clean',
+                drawOwner: 'wmscrossfilter',
+                drawMethod: 'BBOX',
+                features: []
+            } : {...state};
+        }
         default:
             return msDraw(state, action);
     }

--- a/js/reducers/featureselector.js
+++ b/js/reducers/featureselector.js
@@ -45,6 +45,9 @@ function featureselector(state = initialState, action) {
         case 'ZONES_RESET': {
             return initialState;
         }
+        case 'ON_RESET_THIS_ZONE': {
+            return (action.reload) ? initialState : {...state};
+        }
         case 'BASE_CQL_FILTER': {
             return initialState;
         }

--- a/js/reducers/highlight.js
+++ b/js/reducers/highlight.js
@@ -18,6 +18,9 @@ function highlight(state, action) {
         case 'ZONES_RESET': {
             return {...state, status: 'disabled'};
         }
+        case 'ON_RESET_THIS_ZONE': {
+            return (action.reload) ? {...state, status: 'disabled'} : {...state};
+        }
         default:
             return msHighlight(state, action);
     }

--- a/js/utils/LhtacFilterUtils.js
+++ b/js/utils/LhtacFilterUtils.js
@@ -57,36 +57,40 @@ const LhtacFilterUtils = {
         let zone;
         // Get the latest zone with value in the array
         for (let i = spatialField.zoneFields.length - 1; i >= 0; i--) {
-            if (spatialField.zoneFields[i].value) {
+            if (spatialField.zoneFields[i].value && spatialField.zoneFields[i].active) {
                 zone = spatialField.zoneFields[i];
                 break;
             }
         }
 
-        // Get the attribute name (check for dotted notation)
-        let attribute = zone.valueField.indexOf(".") !== -1 ? zone.valueField.split('.')[zone.valueField.split('.').length - 1] : zone.valueField;
+        if (zone) {
+            // Get the attribute name (check for dotted notation)
+            let attribute = zone.valueField.indexOf(".") !== -1 ? zone.valueField.split('.')[zone.valueField.split('.').length - 1] : zone.valueField;
 
-        // Prepare the cql cross layer filter
-        let filter = spatialField.operation +
-            "(" + spatialField.attribute +
-                ", collectGeometries(queryCollection('" +
-                    zone.typeName +
-                    "', '" + zone.geometryName +
-                    "', '" + attribute;
+            // Prepare the cql cross layer filter
+            let filter = spatialField.operation +
+                "(" + spatialField.attribute +
+                    ", collectGeometries(queryCollection('" +
+                        zone.typeName +
+                        "', '" + zone.geometryName +
+                        "', '" + attribute;
 
-        if (zone.value instanceof Array) {
-            filter += " IN (";
-            zone.value.forEach((value, index) => {
-                filter += "''" + value + "''";
-                if (index < zone.value.length - 1) {
-                    filter += ",";
-                }
-            });
-            filter += ")')))";
-        } else {
-            filter += " = ''" + zone.value + "''')))";
+            if (zone.value instanceof Array) {
+                filter += " IN (";
+                zone.value.forEach((value, index) => {
+                    filter += "''" + value + "''";
+                    if (index < zone.value.length - 1) {
+                        filter += ",";
+                    }
+                });
+                filter += ")')))";
+            } else {
+                filter += " = ''" + zone.value + "''')))";
+            }
+            return filter;
         }
-        return filter;
+
+        return null;
     },
     processOGCSpatialFilter: function(json, version) {
         let objFilter;

--- a/queryFormConfig.js
+++ b/queryFormConfig.js
@@ -2,8 +2,6 @@ const queryFormConfig = {
 
    "lhtac:web2014all_mv": {
         searchUrl: "http://demo.geo-solutions.it/geoserver/ows?service=WFS&outputFormat=application/json",
-        showDetailsPanel: false,
-        useMapProjection: false,
         withContainer: false,
         spatialMethodOptions: [
             {id: "ZONE", name: "queryform.spatialfilter.methods.zone"}
@@ -99,8 +97,6 @@ const queryFormConfig = {
     },
     "lhtac:bridge2014all_mv": {
         searchUrl: "http://demo.geo-solutions.it/geoserver/ows?service=WFS&outputFormat=application/json",
-        showDetailsPanel: false,
-        useMapProjection: false,
         withContainer: false,
         spatialMethodOptions: [
             {id: "ZONE", name: "queryform.spatialfilter.methods.zone"}


### PR DESCRIPTION
Several fixes applied:
 - Added radio button to every zonefield. it can be checked only if a value is present and it allows to pass from a zonefield to another one.
 - every time the zonefield change the map is updated
 - if a zonefield becomes empty and it was active, all the features are reloaded without cleaning others zonefield values
 - if a zonefield becomes empty and it was not active, it is only cleaned that specific zonefield
 - removed from config.json : "type": "WPS"
 - removed from queryformconfig.js : showDetailsPanel: false useMapProjection: false,