### PR TITLE
Fixed #52 : added SelectAll and ClearAll functionalities

### DIFF
--- a/js/components/LhtacSpatialFilter.jsx
+++ b/js/components/LhtacSpatialFilter.jsx
@@ -185,10 +185,11 @@ const SpatialFilter = React.createClass({
                                     onFilter={this.props.actions.zoneFilter}
                                     onChange={this.zoneChange}/></Col>
                               </Row>
-                              <Row>
-                                <Col xs={1}><span/></Col>
-                                <Col xs={11} style={{"marginBottom": "15px", "marginTop": "-10px"}}>{(zone.toolbar) ? this.renderToolbar(zone) : null}</Col>
-                              </Row>
+                              {(zone.toolbar) ?
+                                  (<Row>
+                                      <Col xs={1}><span/></Col>
+                                      <Col xs={11} style={{"marginBottom": "15px", "marginTop": "-10px"}}>{this.renderToolbar(zone)}</Col>
+                                  </Row>) : null}
                             </Grid>
                         </div>
                     );

--- a/js/components/LhtacSpatialFilter.jsx
+++ b/js/components/LhtacSpatialFilter.jsx
@@ -8,8 +8,9 @@
 const React = require('react');
 
 const { Panel, Button, ButtonToolbar, Grid, Row, Col} = require('react-bootstrap');
+const Spinner = require('react-spinkit');
 
-const ZoneField = require('../../MapStore2/web/client/components/data/query/ZoneField');
+const ZoneField = require('./ZoneField');
 
 const SpatialFilter = React.createClass({
     propTypes: {
@@ -25,7 +26,8 @@ const SpatialFilter = React.createClass({
         spatialPanelExpanded: React.PropTypes.bool,
         showDetailsPanel: React.PropTypes.bool,
         withContainer: React.PropTypes.bool,
-        actions: React.PropTypes.object
+        actions: React.PropTypes.object,
+        loadingZones: React.PropTypes.object
     },
     contextTypes: {
         messages: React.PropTypes.object
@@ -47,16 +49,19 @@ const SpatialFilter = React.createClass({
                 zoneFilter: () => {},
                 zoneSearch: () => {},
                 zoneSelected: () => {},
+                clearAll: () => {},
                 zoneChange: () => {}
-            }
+            },
+            loadingZones: {}
         };
     },
-    getValues(zone) {
+    getValues(zone, all) {
         let value = zone && zone.value;
         let val = null;
+        let features = [];
+
         if (value !== null) {
-            let values = zone.values;
-            let features = [];
+            let values = zone && zone.values;
             if (values && values.length > 0) {
 
                 features = values.filter((v) => {
@@ -79,18 +84,54 @@ const SpatialFilter = React.createClass({
                 };
             }
         }
+        if (all) {
+            let values = zone && zone.values;
+            if (values && values.length > 0) {
+
+                features = values;
+            }
+            value = values.map((v) => {
+                let valueField2 = v;
+                zone.valueField.split('.').forEach(part => {
+                    valueField2 = valueField2 ? valueField2[part] : null;
+                });
+                return valueField2;
+            });
+            if (zone && zone.multivalue) {
+                val = {
+                    value: value,
+                    feature: features
+                };
+            } else {
+                val = {
+                    value: [value],
+                    feature: [features]
+                };
+            }
+        }
         return val;
     },
-    renderToolbar() {
+    renderLoadingZone(zone) {
+        return this.props.loadingZones[zone.id] ? (<div style={{"float": "left", "paddingLeft": "14px", "paddingTop ": "8px" }}>
+            <Spinner spinnerName="circle" noFadeIn/>
+        </div>) : null;
+    },
+    renderToolbar(zone) {
         return (
-        <ButtonToolbar style={{ marginTop: 10}}>
-            <Button style={{marginTop: 5}} bsSize="small" onClick={this.selectAll}>Select All</Button>
-            <Button style={{marginTop: 5}} bsSize="small" onClick={this.clearAll}>Clear All</Button>
-      </ButtonToolbar>
-            );
+            <ButtonToolbar>
+                <Button style={{marginTop: 5}} bsSize="small" onClick={() => {this.zoneChange(zone.id, this.getValues(zone, true)); }} disabled={zone.values.length > 0 ? false : true}>
+                    Select All
+                </Button>
+                <Button style={{marginTop: 5}} bsSize="small" onClick={() => (zone.value) ? this.clearAll(zone) : {}} disabled={zone.value ? false : true}>
+                    Clear All
+                </Button>
+                {this.renderLoadingZone(zone)}
+            </ButtonToolbar>
+        );
     },
     renderRadios(zone) {
-        let value = this.getValues(zone);
+        // get selected values from the list
+        let value = this.getValues(zone, false);
         return (
           <label key={zone.id} style={{marginLeft: "0px", marginTop: "31px"}}>
             <input
@@ -146,7 +187,7 @@ const SpatialFilter = React.createClass({
                               </Row>
                               <Row>
                                 <Col xs={1}><span/></Col>
-                                <Col xs={11}>{(zone.toolbar) ? this.renderToolbar() : null}</Col>
+                                <Col xs={11} style={{"marginBottom": "15px", "marginTop": "-10px"}}>{(zone.toolbar) ? this.renderToolbar(zone) : null}</Col>
                               </Row>
                             </Grid>
                         </div>
@@ -167,13 +208,13 @@ const SpatialFilter = React.createClass({
             </div>
         );
     },
+    clearAll(zone) {
+        this.props.actions.clearAll(zone);
+    },
     zoneChange(id, value) {
-        // find the zonefield related to the last selected value
+        // find the zonefield that is changing his values
         let zoneField = this.props.spatialField.zoneFields.find((z) => {return z.id === id; });
 
-        /*if ( value.value && value.value.length > 0 &&
-            value.feature && value.feature.length > 0) {*/
-            // if there are some exluded zone set this to be active otherwise...
         if (zoneField && zoneField.exclude && zoneField.exclude.length > 0) {
             this.props.actions.zoneSelected(zoneField, value, zoneField.exclude);
         }else {

--- a/js/components/WMSCrossLayerFilter.jsx
+++ b/js/components/WMSCrossLayerFilter.jsx
@@ -59,7 +59,11 @@ const WMSCrossLayerFilter = React.createClass({
             for (let i = 0; i < nextProps.spatialField.zoneFields.length; i++ ) {
                 let z = nextProps.spatialField.zoneFields[i];
                 if (z.active === true && z.value !== null) {
-                    this.search(nextProps);
+                    if (z.value.length === z.values.length) {
+                        this.search(nextProps, true, z);
+                    } else {
+                        this.search(nextProps, false, z);
+                    }
                 }
             }
         }
@@ -86,9 +90,9 @@ const WMSCrossLayerFilter = React.createClass({
                         <span style={{paddingLeft: "2px"}}><strong><I18N.Message msgId={"queryform.reset"}/ ></strong></span>
                     </Button>
                     <OverlayTrigger placement="right" overlay={(<Tooltip id="lab"><strong><I18N.Message msgId={"lhtac.crossfilter.zoomBtn"}/></strong></Tooltip>)}>
-                    <Button disabled={!this.props.toolbarEnabled || (this.props.zoomArgs === null || this.props.zoomArgs === undefined)} id="zoomtoarea" onClick={this.zoomToSelectedArea}>
-                        <Glyphicon glyph="resize-full"/>
-                    </Button>
+                        <Button disabled={!this.props.toolbarEnabled || (this.props.zoomArgs === null || this.props.zoomArgs === undefined)} id="zoomtoarea" onClick={this.zoomToSelectedArea}>
+                            <Glyphicon glyph="resize-full"/>
+                        </Button>
                     </OverlayTrigger>
                 </ButtonToolbar>
                 <Modal show={this.props.showGeneratedFilter ? true : false} bsSize="large">

--- a/js/components/ZoneField.jsx
+++ b/js/components/ZoneField.jsx
@@ -185,8 +185,10 @@ const ZoneField = React.createClass({
         let label = this.props.label ? (<label>{this.props.label}</label>) : (<span/>);
 
         let error = this.props.error;
-        if (error) {
+        if (error && error.status && error.statusText && error.data) {
             error = typeof error !== "object" ? error : error.status + " " + error.statusText + ": " + error.data;
+        } else {
+            error = typeof error !== "object" ? error : error && error.message || null;
         }
 
         return (

--- a/js/components/ZoneField.jsx
+++ b/js/components/ZoneField.jsx
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+
+const ComboField = require('../../MapStore2/web/client/components/data/query/ComboField');
+
+const FilterUtils = require('../../MapStore2/web/client/utils/FilterUtils');
+
+const ZoneField = React.createClass({
+    propTypes: {
+        zoneId: React.PropTypes.number,
+        url: React.PropTypes.string,
+        typeName: React.PropTypes.string,
+        wfs: React.PropTypes.string,
+        busy: React.PropTypes.bool,
+        values: React.PropTypes.array,
+        value: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.number,
+            React.PropTypes.string,
+            React.PropTypes.array
+        ]),
+        label: React.PropTypes.string,
+        searchText: React.PropTypes.string,
+        searchMethod: React.PropTypes.string,
+        searchAttribute: React.PropTypes.string,
+        sort: React.PropTypes.object,
+        error: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.string
+        ]),
+        comboFilter: React.PropTypes.oneOfType([
+            React.PropTypes.bool,
+            React.PropTypes.string,
+            React.PropTypes.func
+        ]),
+        groupBy: React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.func
+        ]),
+        multivalue: React.PropTypes.bool,
+        open: React.PropTypes.bool,
+        disabled: React.PropTypes.bool,
+        dependsOn: React.PropTypes.object,
+        valueField: React.PropTypes.string,
+        textField: React.PropTypes.string,
+        onSearch: React.PropTypes.func,
+        onFilter: React.PropTypes.func,
+        // onOpenMenu: React.PropTypes.func,
+        onChange: React.PropTypes.func,
+        onSelect: React.PropTypes.func
+    },
+    contextTypes: {
+        messages: React.PropTypes.object
+    },
+    getInitialState() {
+        return { open: false};
+    },
+    getDefaultProps() {
+        return {
+            open: false,
+            zoneId: null,
+            url: null,
+            typeName: null,
+            wfs: "1.1.0",
+            busy: false,
+            values: [],
+            value: null,
+            valueField: null,
+            textField: null,
+            label: null,
+            disabled: false,
+            error: null,
+            searchText: "*",
+            searchMethod: "ilike",
+            searchAttribute: null,
+            comboFilter: "contains",
+            multivalue: true,
+            groupBy: null,
+            onSearch: () => {},
+            onFilter: () => {},
+            // onOpenMenu: () => {},
+            onChange: () => {},
+            onSelect: () => {}
+        };
+    },
+    componentDidMount() {
+        if (this.props.values.length === 0) {
+            const filter = this.getFilter(this.props.searchText, this.props.searchMethod);
+            this.props.onSearch(true, this.props.zoneId);
+            this.props.onFilter(this.props.url, filter, this.props.zoneId);
+        }
+    },
+    getFilter(searchText = "*", operator = "=") {
+        let filterObj = {
+            filterFields: [{
+                attribute: this.props.searchAttribute,
+                operator: operator,
+                value: searchText,
+                type: "list"
+            }]
+        };
+
+        if (this.props.dependsOn) {
+            filterObj.groupFields = [
+                {
+                    id: 1,
+                    logic: "AND",
+                    index: 0
+                }
+            ];
+
+            filterObj.filterFields[0].groupId = 1;
+
+            if (this.props.multivalue) {
+                filterObj.groupFields.push({
+                        id: 2,
+                        logic: "OR",
+                        groupId: 1,
+                        index: 1
+                });
+
+                if (this.props.dependsOn.value instanceof Array) {
+                    this.props.dependsOn.value.forEach((val) => {
+                        filterObj.filterFields.push({
+                            attribute: this.props.dependsOn.field,
+                            operator: this.props.dependsOn.operator || "=",
+                            value: val,
+                            groupId: 2,
+                            type: "list"
+                        });
+                    });
+                } else {
+                    filterObj.filterFields.push({
+                       attribute: this.props.dependsOn.field,
+                       operator: this.props.dependsOn.operator || "=",
+                       value: this.props.dependsOn.value,
+                       groupId: 2,
+                       type: "list"
+                    });
+                }
+            } else {
+                filterObj.filterFields.push({
+                    attribute: this.props.dependsOn.field,
+                    operator: this.props.dependsOn.operator || "=",
+                    value: this.props.dependsOn.value,
+                    groupId: 1,
+                    type: "list"
+                });
+            }
+        }
+
+        const filter = FilterUtils.toOGCFilter(this.props.typeName, filterObj, this.props.wfs, this.props.sort || {
+            sortBy: this.props.searchAttribute,
+            sortOrder: "ASC"
+        });
+
+        return filter;
+    },
+    render() {
+        this.values = [];
+        if (this.props.values && this.props.values.length > 0) {
+            this.values = this.props.values.map((feature) => {
+
+                let valueField = feature;
+                this.props.valueField.split('.').forEach(part => {
+                    valueField = valueField ? valueField[part] : null;
+                });
+
+                let textField = feature;
+                this.props.textField.split('.').forEach(part => {
+                    textField = textField ? textField[part] : null;
+                });
+
+                return {id: valueField, name: textField, feature: feature};
+            });
+        }
+
+        let label = this.props.label ? (<label>{this.props.label}</label>) : (<span/>);
+
+        let error = this.props.error;
+        if (error) {
+            error = typeof error !== "object" ? error : error.status + " " + error.statusText + ": " + error.data;
+        }
+
+        return (
+            <div className="zone-combo">
+                {label}
+                <ComboField
+                    key={new Date().getUTCMilliseconds()}
+                    busy={this.props.busy}
+                    disabled={this.props.disabled}
+                    fieldRowId={this.props.zoneId}
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={this.values}
+                    fieldValue={this.props.value}
+                    fieldName="zone"
+                    fieldException={error}
+                    options={{
+                        defaultOpen: this.state.open
+                    }}
+                    groupBy={this.props.groupBy ?
+                        (option) => option.feature.properties[this.props.groupBy] : () => {} }
+                    multivalue={this.props.multivalue}
+                    comboFilter={this.props.comboFilter}
+                    onSelect={this.props.onSelect}
+                    onUpdateField={this.changeZoneValue}
+                    onToggle={(toggle) => {
+                        if (toggle && (!this.props.values || this.props.values.length < 1)) {
+                            const filter = this.getFilter(this.props.searchText, this.props.searchMethod);
+                            this.props.onSearch(true, this.props.zoneId);
+                            this.props.onFilter(this.props.url, filter, this.props.zoneId);
+                        }
+                    }}/>
+            </div>
+        );
+    },
+    changeZoneValue(id, fieldName, value) {
+        this.setState({open: false});
+        let val;
+        if (this.props.multivalue) {
+            val = {
+                value: value.map((v) => v.id),
+                feature: value.map((v) => v.feature)
+            };
+        } else {
+            val = {
+                value: [value],
+                feature: [this.values.filter((element) => element.id === value)[0].feature]
+            };
+        }
+
+        this.props.onChange(this.props.zoneId, val);
+    }
+});
+
+module.exports = ZoneField;

--- a/js/plugins/AreaFilter.jsx
+++ b/js/plugins/AreaFilter.jsx
@@ -33,6 +33,7 @@ const {
     zoneSelected,
     changeLhtacLayerFilter,
     zoneGetValues,
+    clearAll,
     cleanZone
     } = require('../actions/lhtac');
 
@@ -56,7 +57,12 @@ const SpatialFilterSelector = createSelector([
             showDetailsPanel: state.queryform.showDetailsPanel,
             withContainer: state.queryform.withContainer,
             spatialMethodOptions: state.queryform.spatialMethodOptions,
-            spatialOperations: state.queryform.spatialOperations
+            spatialOperations: state.queryform.spatialOperations,
+            loadingZones: Object.keys(state.tasks).filter((task) => task.indexOf('zoneChange') === 0 && state.tasks[task].running).reduce((previous, current) => {
+                return assign(previous, {
+                    [current.substring('zoneChange'.length)]: true
+                });
+            }, {})
         }));
 
 const SpatialFilter = connect(SpatialFilterSelector, (dispatch) => {
@@ -68,6 +74,7 @@ const SpatialFilter = connect(SpatialFilterSelector, (dispatch) => {
             setActiveZone,
             zoneSelected,
             cleanZone,
+            clearAll,
             zoneChange
         }, dispatch)
     };
@@ -142,6 +149,7 @@ module.exports = {
         }
     }),
     reducers: {
-        areafilter: require('../reducers/areafilter')
+        areafilter: require('../reducers/areafilter'),
+        tasks: require('../../MapStore2/web/client/reducers/tasks')
     }
 };

--- a/js/reducers/queryform.js
+++ b/js/reducers/queryform.js
@@ -7,11 +7,13 @@
  */
 const msQueryform = require('../../MapStore2/web/client/reducers/queryform');
 const queryFormConfig = require('../../queryFormConfig');
-const {union, bbox} = require('turf');
+const {bbox} = require('turf');
+const assign = require('object-assign');
+
 const CLEAN_GEOMETRY = 'CLEAN_GEOMETRY';
 const CLEAN_ZONE = 'CLEAN_ZONE';
+const TASK_SUCCESS = 'TASK_SUCCESS';
 const ON_RESET_THIS_ZONE = 'ON_RESET_THIS_ZONE';
-const assign = require('object-assign');
 
 function shouldReset(aId, dId, zones) {
     let reset = false;
@@ -22,78 +24,6 @@ function shouldReset(aId, dId, zones) {
         reset = (aId === zone.dependson.id) ? true : shouldReset(aId, zone.dependson.id, zones);
     }
     return reset;
-}
-
-function zoneChange(state, action) {
-    let value; let geometry;
-    const zoneFields = state.spatialField.zoneFields.map((field) => {
-        if (field.id === action.id) {
-            value = field.multivalue ? action.value.value : action.value.value[0];
-
-            if (action.value.feature[0]) {
-                let f = action.value.feature[0];
-                let geometryName = f.geometry_name;
-                if (field.multivalue && action.value.feature.length > 1) {
-                    for (let i = 1; i < action.value.feature.length; i++) {
-                        let feature = action.value.feature[i];
-                        if (feature) {
-                            f = union(f, feature);
-                        }
-                    }
-
-                    geometry = {coordinates: f.geometry.coordinates, geometryName: geometryName, geometryType: f.geometry.type};
-                } else {
-                    geometry = {coordinates: f.geometry.coordinates, geometryName: geometryName, geometryType: f.geometry.type};
-                }
-            }
-
-            return {
-                    ...field,
-                    value: value && value.length > 0 ? value : null,
-                    open: false,
-                    geometryName: geometry ? geometry.geometryName : null
-                };
-        }
-
-        if (field.dependson && action.id === field.dependson.id) {
-            let disabled = (!value || (Array.isArray(value) && value.length === 0 )) ? true : false;
-            return {...field,
-                disabled: disabled,
-                values: null,
-                value: null,
-                open: false,
-                checked: false,
-                active: false,
-                dependson: {...field.dependson, value: value}
-            };
-        }else if (field.dependson && shouldReset(action.id, field.dependson.id, state.spatialField.zoneFields)) {
-            return {...field,
-                disabled: true,
-                values: null,
-                value: null,
-                open: false,
-                active: false,
-                checked: false
-            };
-        }
-
-        return field;
-    });
-
-    let extent = bbox({
-        type: "FeatureCollection",
-        features: action.value.feature
-    });
-
-    return {...state, spatialField: {...state.spatialField,
-        zoneFields: zoneFields,
-        geometry: extent && geometry ? {
-            extent: extent,
-            type: geometry.geometryType,
-            coordinates: geometry.coordinates
-        } : null,
-        buttonReset: false
-    }};
 }
 
 function queryform(state, action) {
@@ -114,11 +44,11 @@ function queryform(state, action) {
                 zoneFields: state.spatialField.zoneFields.map((field) => {
                     let f = {
                         ...field,
-                        values: null,
                         value: null,
                         open: false,
                         error: null,
                         active: false,
+                        loadingAll: false,
                         checked: false
                     };
 
@@ -145,7 +75,6 @@ function queryform(state, action) {
                     if (field.id === action.zoneId) {
                         f = {
                         ...field,
-                        values: null,
                         value: null,
                         open: false,
                         error: null,
@@ -178,7 +107,6 @@ function queryform(state, action) {
                   if (field.id === action.zoneId) {
                       f = {
                       ...field,
-                      values: null,
                       value: null,
                       open: false,
                       error: null,
@@ -219,8 +147,67 @@ function queryform(state, action) {
                     }
                 });
         }
-        case 'ZONE_CHANGE': {
-            return zoneChange(state, action);
+        case TASK_SUCCESS: {
+            let name = action.name;
+            let zoneId = parseInt(name.substring('zoneChange'.length), 10);
+            let feature = action.result;
+            let value;
+            let geometry;
+            const zoneFields = state.spatialField.zoneFields.map((field) => {
+                if (field.id === zoneId) {
+                    value = field.multivalue ? action.actionPayload.value : action.actionPayload.value[0];
+                    if (feature) {
+                        let f = feature;
+                        let geometryName = action.actionPayload.featureParams.geometry_name;
+                        geometry = {coordinates: f.geometry.coordinates, geometryName: geometryName, geometryType: f.geometry.type};
+                    }
+
+                    return {
+                            ...field,
+                            value: value && value.length > 0 ? value : null,
+                            open: false,
+                            geometryName: geometry ? geometry.geometryName : null
+                        };
+                }
+                if (field.dependson && zoneId === field.dependson.id) {
+                    let disabled = (!value || (Array.isArray(value) && value.length === 0 )) ? true : false;
+                    return {...field,
+                        disabled: disabled,
+                        values: null,
+                        value: null,
+                        open: false,
+                        checked: false,
+                        active: false,
+                        dependson: {...field.dependson, value: value}
+                    };
+                }else if (field.dependson && shouldReset(zoneId, field.dependson.id, state.spatialField.zoneFields)) {
+                    return {...field,
+                        disabled: true,
+                        values: null,
+                        value: null,
+                        open: false,
+                        active: false,
+                        checked: false
+                    };
+                }
+                return field;
+            });
+
+            let extent = bbox({
+                type: "FeatureCollection",
+                features: action.actionPayload.features
+            });
+
+            return {...state, spatialField: {...state.spatialField,
+                zoneFields: zoneFields,
+                geometry: extent && geometry ? {
+                    extent: extent,
+                    type: geometry.geometryType,
+                    coordinates: geometry.coordinates
+                } : null,
+                buttonReset: false
+            }};
+
         }
         case 'ADD_SIMPLE_FILTER_FIELD': {
             let simpleFilterFields = state.simpleFilterFields || [];

--- a/js/reducers/queryform.js
+++ b/js/reducers/queryform.js
@@ -48,7 +48,6 @@ function queryform(state, action) {
                         open: false,
                         error: null,
                         active: false,
-                        loadingAll: false,
                         checked: false
                     };
 

--- a/js/utils/LhtacFilterUtils.js
+++ b/js/utils/LhtacFilterUtils.js
@@ -54,7 +54,9 @@ const LhtacFilterUtils = {
 
     },
     getZoneCrossFilter(spatialField) {
+        let attribute;
         let zone;
+        let filter = null;
         // Get the latest zone with value in the array
         for (let i = spatialField.zoneFields.length - 1; i >= 0; i--) {
             if (spatialField.zoneFields[i].value && spatialField.zoneFields[i].active) {
@@ -62,19 +64,25 @@ const LhtacFilterUtils = {
                 break;
             }
         }
-
         if (zone) {
             // Get the attribute name (check for dotted notation)
-            let attribute = zone.valueField.indexOf(".") !== -1 ? zone.valueField.split('.')[zone.valueField.split('.').length - 1] : zone.valueField;
+            attribute = zone.valueField.indexOf(".") !== -1 ? zone.valueField.split('.')[zone.valueField.split('.').length - 1] : zone.valueField;
 
             // Prepare the cql cross layer filter
-            let filter = spatialField.operation +
+            filter = spatialField.operation +
                 "(" + spatialField.attribute +
                     ", collectGeometries(queryCollection('" +
                         zone.typeName +
                         "', '" + zone.geometryName +
-                        "', '" + attribute;
-
+                        "', '";
+        }
+        if (zone && zone.values.length === zone.value.length) {
+            // select all
+            // Prepare the cql cross layer filter
+            filter += "INCLUDE')))";
+        } else {
+            // select only chosen ones
+            filter += attribute;
             if (zone.value instanceof Array) {
                 filter += " IN (";
                 zone.value.forEach((value, index) => {
@@ -87,10 +95,8 @@ const LhtacFilterUtils = {
             } else {
                 filter += " = ''" + zone.value + "''')))";
             }
-            return filter;
         }
-
-        return null;
+        return filter;
     },
     processOGCSpatialFilter: function(json, version) {
         let objFilter;

--- a/js/utils/ZoneUtils.js
+++ b/js/utils/ZoneUtils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {union} = require('turf');
+
+const ZoneUtils = {
+    geometryUnion: (geometries, callback, onError, result = null) => {
+        if (geometries.length > 0) {
+            const newResult = result === null ? geometries[0] : union(result, geometries[0]);
+
+            setTimeout(ZoneUtils.geometryUnion.bind(null, geometries.slice(1), callback, onError, newResult), 0);
+        } else {
+            callback(result);
+        }
+    }
+};
+
+module.exports = ZoneUtils;

--- a/js/utils/__tests__/ZoneUtils-test.js
+++ b/js/utils/__tests__/ZoneUtils-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var expect = require('expect');
+var ZoneUtils = require('../ZoneUtils');
+const {union} = require('turf');
+
+var poly1 = {
+  "type": "Feature",
+  "properties": {
+    "fill": "#0f0"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [[
+      [-82.574787, 35.594087],
+      [-82.574787, 35.615581],
+      [-82.545261, 35.615581],
+      [-82.545261, 35.594087],
+      [-82.574787, 35.594087]
+    ]]
+  }
+};
+var poly2 = {
+  "type": "Feature",
+  "properties": {
+    "fill": "#00f"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [[
+      [-82.560024, 35.585153],
+      [-82.560024, 35.602602],
+      [-82.52964, 35.602602],
+      [-82.52964, 35.585153],
+      [-82.560024, 35.585153]
+    ]]
+  }
+};
+var polygons = [poly1, poly2];
+
+var myPolygons = union(poly1, poly2);
+
+describe('Test union', () => {
+    describe('Test union', () => {
+        it('does union', (done) => {
+            ZoneUtils.geometryUnion(polygons, (result) => {
+                expect(result).toEqual(myPolygons);
+                done();
+            }, null, poly1);
+        });
+    });
+});

--- a/queryFormConfig.js
+++ b/queryFormConfig.js
@@ -29,6 +29,7 @@ const queryFormConfig = {
                 label: "ITD District",
                 multivalue: true,
                 disabled: false,
+                toolbar: true,
                 sort: {
                     sortBy: "ITD_Dist_n",
                     sortOrder: "ASC"
@@ -48,6 +49,7 @@ const queryFormConfig = {
                 label: "County",
                 multivalue: true,
                 disabled: false,
+                toolbar: true,
                 sort: {
                     sortBy: "short_name",
                     sortOrder: "ASC"
@@ -67,6 +69,7 @@ const queryFormConfig = {
                 label: "City",
                 multivalue: true,
                 disabled: false,
+                toolbar: false,
                 sort: {
                     sortBy: "short_name",
                     sortOrder: "ASC"
@@ -86,6 +89,7 @@ const queryFormConfig = {
                 searchMethod: "ilike",
                 searchAttribute: "juris_type",
                 disabled: false,
+                toolbar: false,
                 multivalue: true,
                 sort: {
                     sortBy: "name2",
@@ -124,6 +128,7 @@ const queryFormConfig = {
                 label: "ITD District",
                 multivalue: true,
                 disabled: false,
+                toolbar: true,
                 sort: {
                     sortBy: "ITD_Dist_n",
                     sortOrder: "ASC"
@@ -143,6 +148,7 @@ const queryFormConfig = {
                 label: "County",
                 multivalue: true,
                 disabled: false,
+                toolbar: true,
                 sort: {
                     sortBy: "short_name",
                     sortOrder: "ASC"
@@ -162,6 +168,7 @@ const queryFormConfig = {
                 label: "City",
                 multivalue: true,
                 disabled: false,
+                toolbar: false,
                 sort: {
                     sortBy: "short_name",
                     sortOrder: "ASC"
@@ -181,6 +188,7 @@ const queryFormConfig = {
                 searchMethod: "ilike",
                 searchAttribute: "juris_type",
                 disabled: false,
+                toolbar: false,
                 multivalue: true,
                 sort: {
                     sortBy: "name2",


### PR DESCRIPTION
- Opening the area filter tool the values are loaded in order to activate the Select All functionality
- For the district and county zonefield a Select All and Clear All functionalities have been added.
- This functionalities haven't been added to the city and rode jurisdictions zonefield due to the high number of element.