### PR TITLE
Fix #63. Remove Geometry Usage in AreaFilter

### DIFF
--- a/js/actions/lhtac.js
+++ b/js/actions/lhtac.js
@@ -15,9 +15,10 @@ const CHANGE_DOWNLOAD_FORMAT = 'CHANGE_DOWNLOAD_FORMAT';
 const CLEAN_GEOMETRY = 'CLEAN_GEOMETRY';
 const CLEAN_ZONE = 'CLEAN_ZONE';
 const LOADING_SELECT_ALL = 'LOADING_SELECT_ALL';
+const ZONE_CHANGE = 'ZONE_CHANGE';
 
 const {changeLayerProperties} = require('../../MapStore2/web/client/actions/layers');
-const {startTask} = require('../../MapStore2/web/client/actions/tasks');
+
 const {zoneSearchError, zoneFilter, zoneSearch} = require('../../MapStore2/web/client/actions/queryform');
 const {featureSelectorError} = require("../actions/featureselector");
 const {onResetThisZone} = require("../actions/queryform");
@@ -114,7 +115,15 @@ function cleanZone(zoneId) {
         zoneId
     };
 }
+function zoneChange(id, features, value) {
+    return {
+        type: ZONE_CHANGE,
+        id,
+        features,
+        value
 
+    };
+}
 function zoneSelected(zone, value) {
     return (dispatch) => {
         // clean previous geometry
@@ -128,12 +137,8 @@ function zoneSelected(zone, value) {
         // if there is a value in the zoneField update the geometry
         if (value && value.value && value.value.length > 0 &&
             value.feature && value.feature.length > 0) {
-            let actionPayload = {
-                "featureParams": value.feature[0],
-                "value": value.value,
-                "features": value.feature
-            };
-            dispatch(startTask((v, c) => c(v), value.feature, 'zoneChange' + zone.id, actionPayload));
+
+            dispatch(zoneChange(zone.id, value.feature, value.value));
             dispatch(setActiveZone(zone.id, zone.exclude));
         }
     };

--- a/js/actions/lhtac.js
+++ b/js/actions/lhtac.js
@@ -23,7 +23,6 @@ const {featureSelectorError} = require("../actions/featureselector");
 const {onResetThisZone} = require("../actions/queryform");
 
 const FileUtils = require('../../MapStore2/web/client/utils/FileUtils');
-const ZoneUtils = require('../utils/ZoneUtils');
 
 function statsLoading(status) {
     return {
@@ -134,7 +133,7 @@ function zoneSelected(zone, value) {
                 "value": value.value,
                 "features": value.feature
             };
-            dispatch(startTask(ZoneUtils.geometryUnion, value.feature, 'zoneChange' + zone.id, actionPayload));
+            dispatch(startTask((v, c) => c(v), value.feature, 'zoneChange' + zone.id, actionPayload));
             dispatch(setActiveZone(zone.id, zone.exclude));
         }
     };

--- a/js/components/WMSCrossLayerFilter.jsx
+++ b/js/components/WMSCrossLayerFilter.jsx
@@ -21,6 +21,7 @@ const WMSCrossLayerFilter = React.createClass({
     propTypes: {
         zoomArgs: React.PropTypes.array,
         params: React.PropTypes.object,
+        extent: React.PropTypes.object,
         spatialField: React.PropTypes.object,
         toolbarEnabled: React.PropTypes.bool,
         mapConfig: React.PropTypes.object,
@@ -36,6 +37,7 @@ const WMSCrossLayerFilter = React.createClass({
         return {
             params: {},
             mapConfig: {},
+            extent: null,
             spatialField: {},
             toolbarEnabled: true,
             showGeneratedFilter: false,
@@ -55,7 +57,7 @@ const WMSCrossLayerFilter = React.createClass({
         if (nextProps.activeLayer.id !== this.props.activeLayer.id) {
             this.props.actions.changeZoomArgs(null);
         }
-        if (nextProps.spatialField.geometry !== this.props.spatialField.geometry) {
+        if (nextProps.spatialField.extent !== this.props.spatialField.extent) {
             for (let i = 0; i < nextProps.spatialField.zoneFields.length; i++ ) {
                 let z = nextProps.spatialField.zoneFields[i];
                 if (z.active === true && z.value !== null) {
@@ -128,8 +130,8 @@ const WMSCrossLayerFilter = React.createClass({
             }
 
             // Zoom to the selected geometry
-            if (props.spatialField.geometry && props.spatialField.geometry.extent) {
-                const bbox = props.spatialField.geometry.extent;
+            if (props.spatialField.extent && props.spatialField.extent) {
+                const bbox = props.spatialField.extent;
                 const mapSize = props.mapConfig.present.size;
 
                 const newZoom = mapUtils.getZoomForExtent(CoordinatesUtils.reprojectBbox(bbox, "EPSG:4326", props.mapConfig.present.projection), mapSize, 0, 21, null);

--- a/js/components/ZoneField.jsx
+++ b/js/components/ZoneField.jsx
@@ -159,7 +159,7 @@ const ZoneField = React.createClass({
         const filter = FilterUtils.toOGCFilter(this.props.typeName, filterObj, this.props.wfs, this.props.sort || {
             sortBy: this.props.searchAttribute,
             sortOrder: "ASC"
-        });
+        }, null, null, [this.props.valueField.split(".").pop(), this.props.textField.split(".").pop()]);
 
         return filter;
     },

--- a/js/reducers/queryform.js
+++ b/js/reducers/queryform.js
@@ -12,7 +12,7 @@ const assign = require('object-assign');
 
 const CLEAN_GEOMETRY = 'CLEAN_GEOMETRY';
 const CLEAN_ZONE = 'CLEAN_ZONE';
-const TASK_SUCCESS = 'TASK_SUCCESS';
+const ZONE_CHANGE = 'ZONE_CHANGE';
 const ON_RESET_THIS_ZONE = 'ON_RESET_THIS_ZONE';
 
 function shouldReset(aId, dId, zones) {
@@ -146,14 +146,13 @@ function queryform(state, action) {
                     }
                 });
         }
-        case TASK_SUCCESS: {
-            let name = action.name;
-            let zoneId = parseInt(name.substring('zoneChange'.length), 10);
+        case ZONE_CHANGE: {
+            let zoneId = action.id;
             let value;
             let geometry;
             const zoneFields = state.spatialField.zoneFields.map((field) => {
                 if (field.id === zoneId) {
-                    value = field.multivalue ? action.actionPayload.value : action.actionPayload.value[0];
+                    value = field.multivalue ? action.value : action.value.value[0];
 
                     return {
                             ...field,
@@ -188,7 +187,7 @@ function queryform(state, action) {
             // create the extent that contains all the bboxes
             let extent = bbox({
                 type: "FeatureCollection",
-                features: action.actionPayload.features.map( feature => bboxPolygon(feature.properties.bbox))
+                features: action.features.map( feature => bboxPolygon(feature.properties.bbox))
             });
 
             return {...state, spatialField: {...state.spatialField,

--- a/queryFormConfig.js
+++ b/queryFormConfig.js
@@ -34,6 +34,7 @@ const queryFormConfig = {
                     sortBy: "ITD_Dist_n",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [4, 5, 6]
             }, {
                 id: 4,
@@ -54,6 +55,7 @@ const queryFormConfig = {
                     sortBy: "short_name",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 5, 6]
             }, {
                 id: 5,
@@ -74,6 +76,7 @@ const queryFormConfig = {
                     sortBy: "short_name",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 4, 6]
             },
             {
@@ -95,6 +98,7 @@ const queryFormConfig = {
                     sortBy: "name2",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 4, 5]
             }]
         }
@@ -133,6 +137,7 @@ const queryFormConfig = {
                     sortBy: "ITD_Dist_n",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [4, 5, 6]
             }, {
                 id: 4,
@@ -153,6 +158,7 @@ const queryFormConfig = {
                     sortBy: "short_name",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 5, 6]
             }, {
                 id: 5,
@@ -173,6 +179,7 @@ const queryFormConfig = {
                     sortBy: "short_name",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 4, 6]
             },
             {
@@ -194,6 +201,7 @@ const queryFormConfig = {
                     sortBy: "name2",
                     sortOrder: "ASC"
                 },
+                geometry_name: "the_geom",
                 exclude: [3, 4, 5]
             }]
         }


### PR DESCRIPTION
* Improve performances on AreaFilter first load (using paramNames in WFS)
* Use WFS Cross Layer Filtering to perform requests