### PR TITLE
Fix #71. Clean Drawing when selection tools disappear

### DIFF
--- a/js/plugins/FeatureSelector.jsx
+++ b/js/plugins/FeatureSelector.jsx
@@ -139,6 +139,9 @@ const FeatureSelector = React.createClass({
             }
             this.props.changeDrawingStatus("clean", '', 'featureselector', []);
         }
+        if ( this.props.open && !nextProps.open) {
+            this.props.changeDrawingStatus("clean", '', 'featureselector', []);
+        }
     },
     renderError() {
         return this.props.error ? (


### PR DESCRIPTION
Close when FeatureSelector props pass from `open = true ` to `open =false ` 