### PR TITLE
Fix Modal windows z-index

### DIFF
--- a/assets/css/lhtac.css
+++ b/assets/css/lhtac.css
@@ -219,7 +219,7 @@ button.list-group-item:hover {
     position: absolute;
     bottom: 0;
     background-color: white;
-    z-index: 2000;
+    z-index: 1999;
 }
 
 #south-panel .header{


### PR DESCRIPTION
This fixes the issue of the  feature grid that overlaps the print modal. 